### PR TITLE
Correct Mime Type for Atom feed

### DIFF
--- a/custom/views/atom10/index.tpl.php
+++ b/custom/views/atom10/index.tpl.php
@@ -2,7 +2,7 @@
 $limit = $PlanetConfig->getMaxDisplay();
 $count = 0;
 
-header('Content-Type: text/plain; charset=UTF-8');
+header('Content-Type: application/atom+xml; charset=UTF-8');
 echo '<?xml version="1.0" encoding="UTF-8" ?>';
 ?><feed xmlns="http://www.w3.org/2005/Atom">
     <title><?php echo $PlanetConfig->getName(); ?></title>
@@ -12,7 +12,7 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>';
     <link rel="alternate" type="text/html" href="<?php echo $PlanetConfig->getUrl(); ?>" />
     <updated><?php echo date("Y-m-d\TH:i:s\Z") ?></updated>
     <author><name>Author</name></author>
-  
+
     <?php $count = 0; ?>
     <?php foreach ($items as $item): ?>
     <entry xmlns="http://www.w3.org/2005/Atom">
@@ -21,7 +21,7 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>';
         <link rel="alternate" href="<?php echo htmlspecialchars($item->get_permalink());?>"/>
         <published><?php echo $item->get_date('Y-m-d\\TH:i:s+00:00'); ?></published>
         <author><name><?php echo ($item->get_author()? $item->get_author()->get_name() : 'anonymous'); ?></name></author>
-        
+
         <content type="html"><![CDATA[<?php echo $item->get_content();?>]]></content>
     </entry>
     <?php if (++$count == $limit) { break; } ?>


### PR DESCRIPTION
The Atom feed is sent with a text/plain http header, it should be application/atom+xml so as to allow browsers to render it with their built-in feed reader.
