### PR TITLE
Unhtmlspecialchars

### DIFF
--- a/postload.php
+++ b/postload.php
@@ -1,20 +1,10 @@
 <?php
 include_once(dirname(__FILE__).'/app/app.php');
 
-function unhtmlspecialchars( $string ) {
-    $string = str_replace ( '&amp;', '&', $string );
-    $string = str_replace ( '&#039;', '\'', $string );
-    $string = str_replace ( '&quot;', '\"', $string );
-    $string = str_replace ( '&lt;', '<', $string );
-    $string = str_replace ( '&gt;', '>', $string );
-   
-    return $string;
-}
-
 $Planet->addPerson(
     new PlanetPerson(
         '',
-        unhtmlspecialchars($_GET['url']),
+        htmlspecialchars_decode($_GET['url'], ENT_QUOTES),
         ''
     )
 );


### PR DESCRIPTION
code simplification.
Remove unhtmlspecialchar() function only used in postload.php, this is the strict equivalent of htmlspecialchars_decode() in PHP5 which was probably created for some PHP4 compatibility in the past but PHP4 is no longer supported.
