### PR TITLE
Update l10n support:

### DIFF
--- a/app/classes/Simplel10n.class.php
+++ b/app/classes/Simplel10n.class.php
@@ -19,6 +19,18 @@ class Simplel10n {
 
     static function getString($str, $comment='') {
         if(array_key_exists($str, $GLOBALS['locale'])) {
+            return trim(str_replace('{ok}', '', $GLOBALS['locale'][$str]));
+        } else {
+            return $str;
+        }
+    }
+
+    /*
+     * This is the same as getString except that we don't remove the {ok} string
+     * This is needed only for the extraction script
+     */
+    static function extractString($str, $comment='') {
+        if(array_key_exists($str, $GLOBALS['locale'])) {
             return $GLOBALS['locale'][$str];
         } else {
             return $str;

--- a/app/l10n/en.lang
+++ b/app/l10n/en.lang
@@ -1,0 +1,270 @@
+# Translation note:  ** String needs translation **
+;Are you sure you want to purge the cache?
+Are you sure you want to purge the cache?
+
+
+# Translation note:  ** String needs translation **
+;Clear cache
+Clear cache
+
+
+# Translation note:  ** String needs translation **
+;Clear cache:
+Clear cache:
+
+
+# Translation note:  ** String needs translation **
+;Clear
+Clear
+
+
+# Translation note:  ** String needs translation **
+;Clearing the cache will make moonmoon reload all feeds.
+Clearing the cache will make moonmoon reload all feeds.
+
+
+# Translation note:  ** String needs translation **
+;Change administrator password
+Change administrator password
+
+
+# Translation note:  ** String needs translation **
+;New password:
+New password:
+
+
+# Translation note:  ** String needs translation **
+;Change password
+Change password
+
+
+# Translation note:  ** String needs translation **
+;Add Feed
+Add Feed
+
+
+# Translation note:  ** String needs translation **
+;Link:
+Link:
+
+
+# Translation note:  ** String needs translation **
+;Accepted formats are RSS and ATOM. If the link is not a feed, moonmoon will try to autodiscover the feed.
+Accepted formats are RSS and ATOM. If the link is not a feed, moonmoon will try to autodiscover the feed.
+
+
+# Translation note:  ** String needs translation **
+;Manage existing feeds
+Manage existing feeds
+
+
+# Translation note:  ** String needs translation **
+;Number of feeds: %s
+Number of feeds: %s
+
+
+# Translation note:  ** String needs translation **
+;Save changes
+Save changes
+
+
+# Translation note:  ** String needs translation **
+;Delete selected Feeds
+Delete selected Feeds
+
+
+# Translation note:  ** String needs translation **
+;Select :
+Select :
+
+
+# Translation note:  ** String needs translation **
+;All
+All
+
+
+# Translation note:  ** String needs translation **
+;None
+None
+
+
+# Translation note:  ** String needs translation **
+;Selection
+Selection
+
+
+# Translation note:  ** String needs translation **
+;Name
+Name
+
+
+# Translation note:  ** String needs translation **
+;Last entry
+Last entry
+
+
+# Translation note:  ** String needs translation **
+;Website link
+Website link
+
+
+# Translation note:  ** String needs translation **
+;Feed link
+Feed link
+
+
+# Translation note:  ** String needs translation **
+;Not in cache
+Not in cache
+
+
+# Translation note:  ** String needs translation **
+;Password:
+Password:
+
+
+# Translation note:  ** String needs translation **
+;OK
+OK
+
+
+# Translation note:  ** String needs translation **
+;moonmoon administration
+moonmoon administration
+
+
+# Translation note:  ** String needs translation **
+;Back to main page
+Back to main page
+
+
+# Translation note:  ** String needs translation **
+;Logout
+Logout
+
+
+# Translation note:  ** String needs translation **
+;Feeds
+Feeds
+
+
+# Translation note:  ** String needs translation **
+;Administration
+Administration
+
+
+# Translation note:  ** String needs translation **
+;Powered by <a %s>moonmoon</a>
+Powered by <a %s>moonmoon</a>
+
+
+# Translation note:  ** String needs translation **
+;No article
+No article
+
+
+# Translation note:  ** String needs translation **
+;No news, good news.
+No news, good news.
+
+
+# Translation note:  ** String needs translation **
+;Today
+Today
+
+
+# Translation note:  ** String needs translation **
+;Go to original place
+Go to original place
+
+
+# Translation note:  ** String needs translation **
+;This week
+This week
+
+
+# Translation note:  ** String needs translation **
+;This month
+This month
+
+
+# Translation note:  ** String needs translation **
+;Older items
+Older items
+
+
+# Translation note:  ** String needs translation **
+;People
+People
+
+
+# Translation note:  ** String needs translation **
+;Feed
+Feed
+
+
+# Translation note:  ** String needs translation **
+;Website
+Website
+
+
+# Translation note:  ** String needs translation **
+;All feeds in OPML format
+All feeds in OPML format
+
+
+# Translation note:  ** String needs translation **
+;Syndicate
+Syndicate
+
+
+# Translation note:  ** String needs translation **
+;Feed (ATOM)
+Feed (ATOM)
+
+
+# Translation note:  ** String needs translation **
+;Archives
+Archives
+
+
+# Translation note:  ** String needs translation **
+;See all headlines
+See all headlines
+
+
+# Translation note:  ** String needs translation **
+;Source:
+Source:
+
+
+# Translation note:  ** String needs translation **
+;You might want to <a href="install.php">install moonmoon</a>.
+You might want to <a href="install.php">install moonmoon</a>.
+
+
+# Translation note:  ** String needs translation **
+;moonmoon installation
+moonmoon installation
+
+
+# Translation note:  ** String needs translation **
+;Congratulations! Your moonmoon is ready.
+Congratulations! Your moonmoon is ready.
+
+
+# Translation note:  ** String needs translation **
+;What's next?
+What's next?
+
+
+# Translation note:  ** String needs translation **
+;<strong>Delete</strong> <code>install.php</code> with your FTP software.
+<strong>Delete</strong> <code>install.php</code> with your FTP software.
+
+
+# Translation note:  ** String needs translation **
+;Use your password to go to the <a href="./admin/">administration panel</a>
+Use your password to go to the <a href="./admin/">administration panel</a>
+
+

--- a/app/l10n/fr.lang
+++ b/app/l10n/fr.lang
@@ -1,126 +1,70 @@
-;People
-Personnes
-
-;Powered by <a %s>moonmoon</a>
-Propulsé par <a %s>moonmoon</a>
-
-;Feed
-Flux
-
-;Website
-Site Web
-
-;All feeds in OPML format
-Tous les flux au format OPML
-
-;Syndicate
-Syndiquer
-
-;Feed (ATOM)
-Flux (ATOM)
-
-;Archives
-Archives
-
-;See all headlines
-Afficher tous les titres
-
-;Source:
-Source&nbsp;:
-
-;Today
-Aujourd'hui
-
-;This week
-Cette semaine
-
-;This month
-Ce mois
-
-;Older items
-Billets plus anciens
-
-;No article
-Pas d'articles
-
-;No news, good news.
-Pas de nouvelles, bonne nouvelle.
-
-;Go to original place
-Aller à l'emplacement d'origine
-
-# administration panel strings below
-
-;moonmoon installation
-Installation de moonmoon
+;Are you sure you want to purge the cache?
+Êtes-vous sûr de vouloir vider le cache ?
 
 
-;Server is running PHP5
-Le serveur utilise PHP5
-
-;Check your server documentation to activate PHP5.
-Vérifiez la documentation de votre serveur pour activer PHP5
-
-;<code>%s</code> is writable
-<code>%s</code> est accessible en écriture
-
-;Make <code>%s</code> writable with CHMOD
-Donnez les droits en écriture sur <code>%s</code> avec CHMOD
-
-;Congratulations! Your moonmoon is ready.
-Félicitations&nbsp;! Votre moonmoon est prêt.
-
-;What's next?
-Et maintenant &nbsp;?
-
-;<strong>Delete</strong> <code>install.php</code> with your FTP software.
-<strong>Effacez</strong> <code>install.php</code> avec votre logiciel FTP.
-
-;Use your password to go to the <a href="./admin/">administration panel</a>
-Utilisez votre mot de passe pour vous rendre sur la <a href="./admin/">console d'administration</a>
+;Clear cache
+Vider le cache
 
 
-;Feeds
-Flux
+;Clear cache:
+Vider le cache &nbsp;:
 
-;Back to main page
-Retour à l'accueil
 
-;moonmoon administration
-Administration de moonmoon
+;Clear
+Vider
 
-;Logout
-Déconnexion
 
-;Administration
-Administration
+;Clearing the cache will make moonmoon reload all feeds.
+Vider le cache forcera moonmoon à recharger tous les flux.
+
+
+;Change administrator password
+Changer le mot de passe de l'administrateur
+
+
+;New password:
+Nouveau mot de passe &nbsp;:
+
+
+;Change password
+Changer le mot de passe
+
 
 ;Add Feed
 Ajouter un flux
 
+
 ;Link:
 Lien&nbsp;:
+
 
 ;Accepted formats are RSS and ATOM. If the link is not a feed, moonmoon will try to autodiscover the feed.
 Les formats valides sont RSS et ATOM. Si le lien n'est pas un flux, moonmoon essaiera de trouver le flux automatiquement.
 
+
 ;Manage existing feeds
 Gérer les flux
+
 
 ;Number of feeds: %s
 Nombre de flux&nbsp;: %s
 
+
 ;Save changes
 Enregistrer les changements
+
 
 ;Delete selected Feeds
 Effacer les flux sélectionnés
 
+
 ;Select :
 Sélectionner
 
+
 ;All
 Tout
+
 
 ;None
 Aucun
@@ -129,47 +73,144 @@ Aucun
 ;Selection
 Sélection
 
+
 ;Name
 Titre
+
 
 ;Last entry
 Dernière entrée
 
+
 ;Website link
 Lien du site
+
 
 ;Feed link
 Lien du Flux
 
+
 ;Not in cache
 Pas en cache
 
-;Are you sure you want to purge the cache?
-Êtes-vous sûr de vouloir vider le cache ?
-
-;Clear cache:
-Vider le cache &nbsp;:
-
-;Clear cache
-Vider le cache
-
-;Clear
-Vider
-
-;Clearing the cache will make moonmoon reload all feeds.
-Vider le cache forcera moonmoon à recharger tous les flux.
-
-;Change administrator password
-Changer le mot de passe de l'administrateur
-
-;New password:
-Nouveau mot de passe &nbsp;:
-
-;Change password
-Changer le mot de passe
 
 ;Password:
 Mot de passe&nbsp;:
 
+
 ;OK
-OK
+OK {ok}
+
+
+;moonmoon administration
+Administration de moonmoon
+
+
+;Back to main page
+Retour à l'accueil
+
+
+;Logout
+Déconnexion
+
+
+;Feeds
+Flux
+
+
+;Administration
+Administration {ok}
+
+
+;Powered by <a %s>moonmoon</a>
+Propulsé par <a %s>moonmoon</a>
+
+
+;No article
+Pas d'articles
+
+
+;No news, good news.
+Pas de nouvelles, bonne nouvelle.
+
+
+;Today
+Aujourd'hui
+
+
+;Go to original place
+Aller à l'emplacement d'origine
+
+
+;This week
+Cette semaine
+
+
+;This month
+Ce mois
+
+
+;Older items
+Billets plus anciens
+
+
+;People
+Personnes
+
+
+;Feed
+Flux
+
+
+;Website
+Site Web
+
+
+;All feeds in OPML format
+Tous les flux au format OPML
+
+
+;Syndicate
+Syndiquer
+
+
+;Feed (ATOM)
+Flux (ATOM)
+
+
+;Archives
+Archives{ok}
+
+
+;See all headlines
+Afficher tous les titres
+
+
+;Source:
+Source&nbsp;:
+
+
+;You might want to <a href="install.php">install moonmoon</a>.
+Vous voulez probablement <a href="install.php">installer moonmoon</a>.
+
+
+;moonmoon installation
+Installation de moonmoon
+
+
+;Congratulations! Your moonmoon is ready.
+Félicitations&nbsp;! Votre moonmoon est prêt.
+
+
+;What's next?
+Et maintenant &nbsp;?
+
+
+;<strong>Delete</strong> <code>install.php</code> with your FTP software.
+<strong>Effacez</strong> <code>install.php</code> avec votre logiciel FTP.
+
+
+;Use your password to go to the <a href="./admin/">administration panel</a>
+Utilisez votre mot de passe pour vous rendre sur la <a href="./admin/">console d'administration</a>
+
+

--- a/custom/views/default/index.tpl.php
+++ b/custom/views/default/index.tpl.php
@@ -26,9 +26,9 @@ header('Content-type: text/html; charset=UTF-8');
             <?php if (0 == count($items)) : ?>
                 <div class="article">
                     <h2 class="article-title">
-                        No article
+                        <?=_g('No article', 'note de trad')?>
                     </h2>
-                    <p class="article-content">No news, good news.</p>
+                    <p class="article-content"><?=_g('No news, good news.')?></p>
                 </div>
             <?php else : ?>
                 <?php foreach ($items as $item): ?>


### PR DESCRIPTION
- improved regex logic in the extraction parser (fixes a couple of bugs in edge cases)
- *.tpl.php files were not parsed because of the double dot, now fixed
- strings requiring translation are now indicated in the source file to make them stand out
- support for the {ok} tag, adding this tag allows the localizer to indicate that a string remains in English (or that it is spelt the same in his language)
- add an english reference file, in case we want to send it to volunteers
