### PR TITLE
Only produce output if there are any errors to report

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -6,4 +6,6 @@ if (0 < $Planet->loadOpml(dirname(__FILE__).'/custom/people.opml')) {
     $Planet->download(1.0);
 }
 
-var_dump($Planet->errors);
+foreach ($Planet->errors as $error) {
+    echo $error->toString()."\n";
+}


### PR DESCRIPTION
`var_dump()` outputs something even if there're not errors, so this makes it silent in non-error situations (and prints errors according to the `PlanetError::toString()`.
