### PR TITLE
Fix wrong include path for Cache

### DIFF
--- a/atom.php
+++ b/atom.php
@@ -1,6 +1,6 @@
 <?php
 include_once(__DIR__.'/app/app.php');
-include_once(__DIR__.'/app/lib/Cache.php');
+include_once(__DIR__.'/app/classes/Cache.php');
 
 if ($Planet->loadOpml(__DIR__.'/custom/people.opml') == 0) exit;
 

--- a/atom.php
+++ b/atom.php
@@ -1,6 +1,5 @@
 <?php
 include_once(__DIR__.'/app/app.php');
-include_once(__DIR__.'/app/classes/Cache.php');
 
 if ($Planet->loadOpml(__DIR__.'/custom/people.opml') == 0) exit;
 

--- a/index.php
+++ b/index.php
@@ -1,6 +1,5 @@
 <?php
 include_once(__DIR__.'/app/app.php');
-include_once(__DIR__.'/app/classes/Cache.php');
 
 //Installed ?
 if (!isset($Planet)) {

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 include_once(__DIR__.'/app/app.php');
-include_once(__DIR__.'/app/lib/Cache.php');
+include_once(__DIR__.'/app/classes/Cache.php');
 
 //Installed ?
 if (!isset($Planet)) {


### PR DESCRIPTION
Caching works better with this. The include error was silenced by the error_reporting directive in app.php.